### PR TITLE
ne pas forcer la fin de ligne lf pour l'instant

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # Declare files that will always have LF line endings on checkout.
-* text eol=lf
+#* text eol=lf


### PR DESCRIPTION
le fichier .gitattributes déclare des fins de ligne LF (ce qui serait
une bonne chose car normalement git sous windows convertit tout seul de
CR/LF à LF et inversement, moyennant éventuellement une option de
configuration), mais les fichiers contiennent en réalité les fins de
ligne CR/LF dans les fichiers.

Une solution plus pérenne serait de convertir tous les fichiers de CR/LF
vers LF et remettre le fichier .gitattributes comme d'origine.
