### PR TITLE
typo : blocs définies / blocs définis

### DIFF
--- a/doc/Blocs.txt
+++ b/doc/Blocs.txt
@@ -21,7 +21,7 @@ Evènements disponibles :
 
   ...
 
-Blocs définies :
+Blocs définis :
 
   planter_orangers()
 </pre>
@@ -48,7 +48,7 @@ Entrez donc :
 Et vous devriez voir dans la définition du bloc :
 
 <pre>
-Blocs définies :
+Blocs définis :
   planter_orangers(salle)
 </pre>
 

--- a/src/primaires/scripting/editeurs/edt_script.py
+++ b/src/primaires/scripting/editeurs/edt_script.py
@@ -183,7 +183,7 @@ class EdtScript(Editeur):
         else:
             msg += "|att|Aucun évènement n'est disponible pour cet objet.|ff|"
 
-        msg += "\n\nBlocs définies :\n"
+        msg += "\n\nBlocs définis :\n"
         if script.blocs:
             for bloc in sorted(script.blocs.values(), \
                     key=lambda bloc: bloc.nom):


### PR DESCRIPTION
- correction de l'aide à ce sujet
