### PR TITLE
supsortie ne doit pas toujour supprimer la réciproque

### DIFF
--- a/src/primaires/salle/commandes/supsortie/__init__.py
+++ b/src/primaires/salle/commandes/supsortie/__init__.py
@@ -62,9 +62,18 @@ class CmdSupsortie(Commande):
         
         d_salle = salle.sorties[direction].salle_dest
         dir_opposee = salle.sorties.get_nom_oppose(direction)
-        
-        d_salle.sorties.supprimer_sortie(dir_opposee)
+
+        # ne supprimer la sortie réciproque que si elle est vraiment réciproque
+        corresp = salle.sorties[direction].correspondante
+        reciproque_definie = corresp is not None and corresp != ""
+        if reciproque_definie:
+            d_salle.sorties.supprimer_sortie(dir_opposee)
+
         salle.sorties.supprimer_sortie(direction)
-        personnage << "|att|La sortie {} a bien été supprimée de la salle " \
-                "courante.\nLa réciproque a également été supprimée (sortie " \
-                "{} dans {}).|ff|".format(direction, dir_opposee, d_salle)
+        message = "La sortie {} a bien été supprimée de la salle " \
+            "courante.".format(direction)
+        if reciproque_definie:
+            message += "\nLa réciproque a également été supprimée (sortie " \
+                "{} dans {}).".format(dir_opposee, d_salle)
+
+        personnage << "|att|" + message + "|ff|"


### PR DESCRIPTION
Quand la sortie à supprimer n'a pas de sortie réciproque
(sortie.correspondante vaut None ou ""), ne pas supprimer la sortie qui
va dans le sens inverse dans la salle pointée.
