### PR TITLE
Restaurer la couleur neutre après réponse à options langue

### DIFF
--- a/src/primaires/joueur/masques/langue/__init__.py
+++ b/src/primaires/joueur/masques/langue/__init__.py
@@ -59,7 +59,7 @@ class Langue(Masque):
         if not langue:
             raise ErreurValidation( \
                 "|err|Précisez une langue disponible (|ff||ent|anglais|ff| " \
-                "|err| ou |ff||ent|français|ff||err|).")
+                "|err| ou |ff||ent|français|ff||err|).|ff|")
         
         langue = langue.split(" ")[0].lower()
         langue = supprimer_accents(langue)


### PR DESCRIPTION
Sans cela on reste en rouge après la fin du message "Précisez une langue
disponible (anglais ou français)"
