### PR TITLE
Essai de correction du rapport 3514.

### DIFF
--- a/src/primaires/objet/commandes/prendre/__init__.py
+++ b/src/primaires/objet/commandes/prendre/__init__.py
@@ -55,6 +55,7 @@ class CmdPrendre(Commande):
         nom_objet = self.noeud.get_masque("nom_objet")
         nom_objet.proprietes["conteneurs"] = \
                 "dic_masques['conteneur'] and " \
+                "hasattr(dic_masques['conteneur'].objet, 'conteneur') and " \
                 "(dic_masques['conteneur'].objet.conteneur.iter_nombres(), " \
                 ") or (personnage.salle.objets_sol.iter_nombres(), )"
         nom_objet.proprietes["quantite"] = "True"


### PR DESCRIPTION
Si on essaie de prendre un objet depuis un objet qui n'est pas un
conteneur, on a une exception qui est levée. Ce patchset permet de
l'éviter mais je ne suis pas sûr que cela soit la meilleure correction
car je ne maîtrise pas encore le système des masques.