### PR TITLE
Correctif d'une exception levée par la commande trouver.

### DIFF
--- a/src/primaires/recherche/filtres/nombre.py
+++ b/src/primaires/recherche/filtres/nombre.py
@@ -105,7 +105,10 @@ class Nombre(TypeFiltre):
                 if valeur.startswith(operateur):
                     valeur = valeur[len(operateur):]
                     valeur = valeur.replace(",", ".")
-                    valeur = float(valeur)
+                    try:
+                        valeur = float(valeur)
+                    except ValueError:
+                        raise TypeError("format de nombre {} inconnu".format(repr(valeur)))
                     return fonction(attribut, valeur)
 
         raise TypeError("format de nombre {} inconnu".format(repr(valeur)))


### PR DESCRIPTION
La commande trouver avec l'option -i levait une exception non traitée
si ce qui suivait l'opérateur n'était pas un nombre. Cela affiche
maintenant une erreur propre.

Rapport 3528.