### PR TITLE
Correction de l'opérateur intervalle pour les filtres.

### DIFF
--- a/src/primaires/recherche/filtres/nombre.py
+++ b/src/primaires/recherche/filtres/nombre.py
@@ -93,8 +93,8 @@ class Nombre(TypeFiltre):
         intervalle = RE_COMPLETE.search(valeur)
         if intervalle:
             groupes = intervalle.groups()
-            borne_inf = groupes[0] + "." + groupes[1] if groupes[1] else "0"
-            borne_sup = groupes[2] + "." + groupes[3] if groupes[3] else "0"
+            borne_inf = groupes[0] + "." + (groupes[1] if groupes[1] else "0")
+            borne_sup = groupes[2] + "." + (groupes[3] if groupes[3] else "0")
             borne_inf = float(borne_inf)
             borne_sup = float(borne_sup)
             return borne_inf <= attribut <= borne_sup


### PR DESCRIPTION
Trouver rapport -i <3>8 fonctionne maintenant.

(en revanche la syntaxe dit l'inverse de ce que ça fait...)

Rapport 3530.