### PR TITLE
Sortir la tête de l'eau réinitialise la progression de la noyade.

### DIFF
--- a/src/primaires/scripting/actions/donner_air.py
+++ b/src/primaires/scripting/actions/donner_air.py
@@ -59,8 +59,4 @@ class ClasseAction(Action):
         if personnage.est_mort() or personnage.est_immortel():
             return
 
-        nom = "noyade_" + personnage.nom_unique
-        if nom in importeur.diffact.actions:
-            # On supprime l'ancienne action
-            importeur.diffact.retirer_action(nom)
-            importeur.diffact.ajouter_action(nom, 5, personnage.act_noyer, 5)
+        personnage.degre_noyade = 0


### PR DESCRIPTION
Et ce, même si cela se fait furtivement. Il y avait un bug par lequel le
fait de sortir la tête de l'eau trop peu de temps ne réinitialisait pas
la progression et l'on pouvait donc se noyer juste après avoir sorti la
tête de l'eau et replongé.

Rapport 3469

Non testé, si tu préfères je prends le temps de créer des salles dans mon instance pour faire un test.