### PR TITLE
Correction de "infos tonneau d'eau douce"

### DIFF
--- a/src/secondaires/navigation/types/tonneau_eau.py
+++ b/src/secondaires/navigation/types/tonneau_eau.py
@@ -82,9 +82,15 @@ class TonneauEau(BaseType):
 
     # Actions sur les objets
     def regarder(self, personnage):
-        """Quand on regarde la boussole."""
+        """Quand on regarde le tonneau."""
         moi = BaseType.regarder(self, personnage)
-        contenu = self.gorgees_contenu / self.gorgees_max_contenu
+        # Cette description peut être appelée dans une échoppe, suite à
+        # l'utilisation de la commande "infos", donc self.gorgees_contenu
+        # peut être absent.
+        gorgees_contenu = getattr(self, "gorgees_contenu",
+                self.gorgees_max_contenu)
+
+        contenu = gorgees_contenu / self.gorgees_max_contenu
         if contenu == 0:
             retour = "Ce tonneau est vide."
         elif contenu <= 0.05:
@@ -98,7 +104,7 @@ class TonneauEau(BaseType):
         elif contenu < 0.6:
             retour = "Ce tonneau est à moitié vide... ou à moitié plein."
         elif contenu < 0.8:
-            retour = "Ce tonneau est rempli au trois quart."
+            retour = "Ce tonneau est rempli aux trois quarts."
         elif contenu < 0.95:
             retour = "Ce tonneau est presque entièrement rempli."
         else:


### PR DESCRIPTION
L'erreur :
AttributeError: 'TonneauEau' object has no attribute 'gorgees_contenu'

Ne pas utiliser l'attribut gorgees_contenu pour la description des
tonneaux pas encore instanciés (en magasin).