### PR TITLE
On n'appâte pas en pleine pêche et on ne gaspille pas les appats.

### DIFF
--- a/src/secondaires/peche/commandes/appater/__init__.py
+++ b/src/secondaires/peche/commandes/appater/__init__.py
@@ -42,13 +42,13 @@ class CmdAppater(Commande):
         self.schema = "<nom_objet>"
         self.aide_courte = "appâte un ameçon"
         self.aide_longue = \
-            "Cette commande permet d'appâter un ameçon. Vous devez " \
+            "Cette commande permet d'appâter un hameçon. Vous devez " \
             "tenir une canne à pêche et préciser le nom de l'appât. " \
             "Certains appâts, plus durs à trouver que d'autres, " \
             "attirent aussi plus le poisson et peuvent augmenter la " \
             "chance de pêcher une prise rare. Dès lors que vous avez " \
             "pêché quelque chose, vous devez appâter de nouveau " \
-            "l'ameçon de la canne avant de la relancer."
+            "l'hameçon de la canne avant de la relancer."
     
     def ajouter(self):
         """Méthode appelée lors de l'ajout de la commande à l'interpréteur"""
@@ -78,6 +78,12 @@ class CmdAppater(Commande):
             personnage << "|err|Vous n'équipez aucune canne à pêche.|ff|"
             return
         
+        if (appat.prototype == canne.appat.prototype):
+            personnage << "|err|Vous avez déjà appâté {} avec {}.".format(
+                    canne.get_nom(), appat.get_nom())
+            return
+        
+        personnage.agir("appater")
         appat.contenu.retirer(appat)
         a_appat = canne.appat
         if a_appat:


### PR DESCRIPTION
Ajout de l'appel à personnage.agir pour vérifier que l'état en cours
nous permet d'appâter (et la pêche est bien un état qui ne le permet pas).

Sinon, si l'appat qu'on s'apprête à utiliser est identique à celui déjà
en place (même prototype), ne rien faire.

Bug 499.