### PR TITLE
Rendre "regarder [détail]" insensible à la casse.

### DIFF
--- a/src/primaires/salle/masques/observable/__init__.py
+++ b/src/primaires/salle/masques/observable/__init__.py
@@ -146,7 +146,7 @@ class Observable(Masque):
                         break
 
         if not elt:
-            nom = supprimer_accents(nom)
+            nom = supprimer_accents(nom).lower()
             if salle.details.detail_existe(nom, flottants=True):
                 detail = salle.details.get_detail(nom, flottants=True)
                 nb += 1


### PR DESCRIPTION
Comme pour les autres objets qu'on peut regarder.

Bug 2243.