### PR TITLE
Correction d'une erreur quand on attache un familier

### DIFF
--- a/src/secondaires/familier/commandes/familier/attacher.py
+++ b/src/secondaires/familier/commandes/familier/attacher.py
@@ -59,6 +59,11 @@ class PrmAttacher(Parametre):
         familier = dic_masques["nom_familier"].familier
         fiche = familier.fiche
         pnj = familier.pnj
+
+        if "attache" in pnj.etats:
+            personnage << "|err|Vous avez déjà attaché {}.|ff|".format(pnj)
+            return
+
         personnage.agir("attacherfamilier")
         if personnage.equipement.cb_peut_tenir() < 1:
             personnage << "|err|Il vous faut au moins une main libre.|ff|"
@@ -73,7 +78,7 @@ class PrmAttacher(Parametre):
         pris = []
         for perso in salle.personnages:
             if "attache" in perso.etats:
-                etat = personnage.etats.get("attache")
+                etat = perso.etats.get("attache")
                 pris.append(etat.barre_attache)
 
         libres = []


### PR DESCRIPTION
* Dans une salle qui comporte déjà un familier attaché, cela levait une
  erreur, corrigée (mauvais nom de variable)
* Ajout : si le familier qu'on tente d'attacher est déjà attaché, on le
  dit au joueur.

Bug 3551