### PR TITLE
Réellement corriger le problème des conteneurs dans eux-mêmes.

### DIFF
--- a/src/primaires/objet/commandes/poser/__init__.py
+++ b/src/primaires/objet/commandes/poser/__init__.py
@@ -81,10 +81,15 @@ class CmdPoser(Commande):
                 return
 
             qtt = min(nombre_restant, qtt)
-
-            if dans and objet.cle == dans.cle:
+            if dans and objet is dans:
                 personnage << "Impossible de mettre {} dans soi-même !" \
                         "".format(objet.nom_singulier)
+                return
+
+            if dans and objet.est_de_type("conteneur") \
+                    and objet.contient_recursif(dans):
+                personnage << "Impossible de mettre {} dans un objet " \
+                        "qu'il contient lui-même.".format(objet.nom_singulier)
                 return
 
             if dans and not (dans.est_de_type("conteneur") and \

--- a/src/primaires/objet/types/conteneur.py
+++ b/src/primaires/objet/types/conteneur.py
@@ -143,6 +143,20 @@ class Conteneur(BaseType):
 
         return False
 
+    def contient_recursif(self, objet):
+        """ Retourne True si le conteneur ou un de ses enfants contient l'objet
+
+        Aucun test de quantité ici contrairement à la méthode contient.
+
+        """
+        for o in self.conteneur:
+            if o is objet:
+                return True
+            if o.est_de_type("conteneur") and o.contient_recursif(objet):
+                return True
+
+        return False
+
     def combien_dans(self, objet):
         """Retourne combien d'objet indiqué sont dans le conteneur."""
         for o, qtt in self.conteneur.iter_nombres():


### PR DESCRIPTION
Ne pas tester la clé, qui correspond au prototype, mais l'identité des
objets. Et empêcher de mettre un objet dans un objet qu'il contient
lui-même.

Bug 1136.