### PR TITLE
Permettre d'équiper un objet tenu à la main.

### DIFF
--- a/src/primaires/objet/commandes/porter/__init__.py
+++ b/src/primaires/objet/commandes/porter/__init__.py
@@ -60,15 +60,14 @@ class CmdPorter(Commande):
         objet, conteneur = objets
         personnage.agir("porter")
 
-        # Vérifie que l'objet à équiper n'est pas sur un membre peut tenir
-        tenir = False
+        # Si l'objet est tenu en main, ne pas exiger une main libre
+        est_tenu = False
         for membre in personnage.equipement.membres:
-            o = membre.equipe and membre.equipe[-1] or None
-            if membre.tester("peut tenir") and o is objet:
-                tenir = True
+            if membre.peut_tenir() and membre.tenu is objet:
+                est_tenu = True
                 break
 
-        if personnage.equipement.cb_peut_tenir() < 1 and not tenir:
+        if not est_tenu and personnage.equipement.cb_peut_tenir() < 1:
             personnage << "|err|Il vous faut au moins une main libre pour " \
                     "vous équiper.|ff|"
             return

--- a/src/primaires/perso/membre.py
+++ b/src/primaires/perso/membre.py
@@ -140,7 +140,7 @@ class Membre(BaseObj):
         # Un emplacement est considéré comme libre si aucun objet n'est tenu
         # ni équipé
         equipable = False
-        if self.tenu is None:
+        if self.tenu is None or self.tenu is objet:
             equipable = True
 
         if objet is None:


### PR DESCRIPTION
Et ce même si l'autre main n'est pas libre.

Bug 3564.