### PR TITLE
Correction modification type de contenu des conteneurs.

### DIFF
--- a/src/primaires/interpreteur/editeur/selection.py
+++ b/src/primaires/interpreteur/editeur/selection.py
@@ -87,6 +87,8 @@ class Selection(Editeur):
             elif self.liste:
                 liste_sa = [supprimer_accents(l) for l in self.liste]
                 if msg_sa in liste_sa:
+                    if "*" in selectionnes:
+                        selectionnes.remove("*")
                     selectionnes.append(self.liste[liste_sa.index(msg_sa)])
                 else:
                     self.pere << "Élément introuvable : {}".format(msg)


### PR DESCRIPTION
L'éditeur prenait en compte les modifications mais oubliait de retirer
la valeur "*", ce qui causait des problèmes d'affichage et des levées
d'exceptions lors de la manipulation des objets concernés.

Bug r3560