### PR TITLE
Retrait de la mention "baignant dans son sang" lorsqu'un perso meurt.

### DIFF
--- a/src/primaires/combat/combat.py
+++ b/src/primaires/combat/combat.py
@@ -221,8 +221,7 @@ class Combat:
                         except DepassementStat:
                             combattu.envoyer("|att|C'en est trop ! Vous " \
                                     "plongez dans l'inconscience.|ff|")
-                            combattu.salle.envoyer("{} s'écroule sur le sol, " \
-                                    "baignant dans son sang.", combattu)
+                            combattu.salle.envoyer("{} s'écroule sur le sol.", combattu)
                             combattant.tuer(combattu)
                             combattu.mourir(adversaire=combattant)
                 else:


### PR DESCRIPTION
En effet, tous les personnages n'ont pas forcément de sang. Par exemple
les squelettes.

Rapport 380 (en partie)
