### PR TITLE
Modifications de l'affichage des navires dans les salles.

### DIFF
--- a/src/secondaires/navigation/__init__.py
+++ b/src/secondaires/navigation/__init__.py
@@ -163,7 +163,7 @@ class Module(BaseModule):
 
         # Ajout d'hooks
         importeur.hook.ajouter_hook("navire:sombre",
-                "Hook appelé quand un navire fait nauffrage.")
+                "Hook appelé quand un navire fait naufrage.")
 
         BaseModule.config(self)
 
@@ -312,7 +312,7 @@ class Module(BaseModule):
 
         # Ajout d'évènements
         importeur.evt.ajouter_evenement("sombre", "Un navire sombre",
-                "Nauffrage de {navire.cle}.", "navire:sombre")
+                "Naufrage de {navire.cle}.", "navire:sombre")
         BaseModule.init(self)
 
     def ajouter_commandes(self):
@@ -645,7 +645,7 @@ class Module(BaseModule):
                     navire.virer(orientation)
 
     def nauffrages(self):
-        """Gère les nauffrages."""
+        """Gère les naufrages."""
         self.importeur.diffact.ajouter_action("nauffrages", 5,
                 self.nauffrages)
         for navire in list(self.navires.values()):
@@ -732,8 +732,8 @@ class Module(BaseModule):
             for t_salle in navire.salles.values():
                 if t_salle.amarre and t_salle.amarre.attachee is salle:
                     e = "" if navire.modele.masculin else "e"
-                    liste_messages.insert(0, "{} est amarré{e} ici.".format(
-                            navire.desc_survol.capitalize(), e=e))
+                    liste_messages.insert(0, "*  {} est amarré{e} ici.".format(
+                            navire.desc_survol, e=e))
                     return
 
     def navire_accoste(self, salle, liste_messages, flags):
@@ -749,9 +749,8 @@ class Module(BaseModule):
         if sortie and sortie.salle_dest and hasattr(sortie.salle_dest,
                 "navire"):
             navire = sortie.salle_dest.navire
-            e = "" if navire.modele.masculin else "e"
-            liste_messages.insert(0, "{} a accosté{e} ici.".format(
-                        navire.desc_survol.capitalize(), e=e))
+            liste_messages.insert(0, "*  {} a accosté ici.".format(
+                        navire.desc_survol))
 
     def combat_matelot(self, pnj, arrive):
         """Méthode appelé quand un PNJ arrive dans la salle d'un autre.

--- a/src/secondaires/navigation/navire.py
+++ b/src/secondaires/navigation/navire.py
@@ -1096,7 +1096,7 @@ class Navire(Vehicule):
         if elt_passerelle:
             elt_passerelle.replier()
 
-        # Cherche la salle la plus proche du nauffrage
+        # Cherche la salle la plus proche du naufrage
         x, y, z = self.position.tuple
         salles = [s for s in importeur.salle._coords.values() if \
                 hasattr(s, "coords") and s.coords.z == z and s.nom_terrain in \


### PR DESCRIPTION
- Ajout d'une astérisque et d'une légère indentation.
- Suppression de l'appel à capitalize, qui avait pour effet de passer en
  minuscules les noms des bateaux.
- Correction de l'accord féminin pour "a accosté".
- Au passage correction de nauffrage en naufrage à divers endroits du
  code, sauf pour les noms de variables et identifants.
