### PR TITLE
+ d'informations sur les personnages pour les imms.

### DIFF
--- a/src/primaires/joueur/joueur.py
+++ b/src/primaires/joueur/joueur.py
@@ -225,8 +225,13 @@ class Joueur(Personnage):
         elif hasattr(personnage, "retenus") and self in personnage.retenus \
                 and retenu:
             return personnage.retenus[self]
+        elif hasattr(personnage, "controle_par") and personnage.controle_par:
+            return self.get_nom_pour(personnage.controle_par, retenu)
         else:
             return self.get_distinction_visible()
+
+    def ajout_description_pour_imm(self):
+        return " |vr|[Joueur {}]|ff|".format(self.nom)
 
     def sans_prompt(self):
         """Désactive le prompt pour le prochain message envoyé."""

--- a/src/primaires/perso/personnage.py
+++ b/src/primaires/perso/personnage.py
@@ -1237,8 +1237,11 @@ class Personnage(BaseObj):
         equipement = self.equipement
         msg = ""
         if notifier:
-            msg = "Vous regardez {} :\n".format(self.get_nom_pour(
+            msg = "Vous regardez {} :".format(self.get_nom_pour(
                     personnage, retenu=False))
+            if personnage.est_immortel():
+                msg += self.ajout_description_pour_imm()
+            msg += "\n"
         if hasattr(self, "description"):
             msg += "\n" + self.description.regarder(personnage=personnage,
                     elt=self) + "\n\n"
@@ -1281,6 +1284,10 @@ class Personnage(BaseObj):
             personnage.salle.envoyer("{} regarde {}.", personnage, self)
         else:
             return msg
+
+    def ajout_description_pour_imm(self):
+        """ Complément d'information pour l'imm qui regarde le personnage """
+        return ""
 
     def tomber(self):
         """self tombe de salles en salles."""

--- a/src/primaires/pnj/pnj.py
+++ b/src/primaires/pnj/pnj.py
@@ -196,6 +196,9 @@ class PNJ(Personnage):
 
         return self.nom_singulier
 
+    def ajout_description_pour_imm(self):
+        return " |vr|[{}: {}]|ff|".format(self.cle, self.identifiant)
+
     def est_connecte(self):
         return True
 


### PR DESCRIPTION
* Quand on contrôle un PNJ, on voit les noms des joueurs qu'on avait
  retenus en tant que joueur imm.
* Quand on regarde un PNJ en tant qu'imm, son prototype et son
  identifiant sont affichés à côté de sa distinction.
* Quand on regarde un joueur en tant qu'imm, son nom est affiché à côté
  de sa distinction.