### PR TITLE
Ne pas afficher le proto en plus de l'identifiant pour les imms.

### DIFF
--- a/src/primaires/pnj/pnj.py
+++ b/src/primaires/pnj/pnj.py
@@ -197,7 +197,7 @@ class PNJ(Personnage):
         return self.nom_singulier
 
     def ajout_description_pour_imm(self):
-        return " |vr|[{}: {}]|ff|".format(self.cle, self.identifiant)
+        return " |vr|[{}]|ff|".format(self.identifiant)
 
     def est_connecte(self):
         return True


### PR DESCRIPTION
Quand on regarde un PNJ, le prototype est redondant avec l'identifiant,
donc on n'affiche que l'identifiant.