### PR TITLE
Correction du passage à la ligne des commentaires des rapports.

### DIFF
--- a/src/secondaires/rapport/rapport.py
+++ b/src/secondaires/rapport/rapport.py
@@ -247,7 +247,7 @@ class Rapport(BaseObj):
                 ret += "\n {:> 2} - par {}, {}".format(i + 1, auteur,
                         get_date(commentaire.date.timetuple()))
                 ret += "\n      " + ("\n      ").join(wrap(
-                        echapper_accolades(commentaire.texte), 70))
+                        echapper_accolades(commentaire.texte), 69))
 
         return ret
 


### PR DESCRIPTION
Les lignes ne doivent pas dépasser 75 caractères afin de tenir dans un
mudmail sans que l'objet Description ne force un passage à la ligne non
prévu, qui casse la mise en page (on se retrouve en général avec un mot
tout seul à la ligne).

Comme l'indentation est de 6 caractères, le commentaire doit wrapper à
69 et non 70.

Rapport 3558