### PR TITLE
Retrait de "équipage ordre ?" et de sa mention dans l'aide.

### DIFF
--- a/src/secondaires/navigation/commandes/equipage/ordre.py
+++ b/src/secondaires/navigation/commandes/equipage/ordre.py
@@ -51,15 +51,11 @@ class PrmOrdre(Parametre):
             "précise. Pour chaque ordre il existe deux notations : " \
             "une notation longue (qui est la plus compréhensible) et " \
             "une notation courte qui s'écrit plus rapidement, n'étant " \
-            "composée que de quelques lettres et chiffres. Entrez " \
-            "%équipage% %équipage:ordre%|cmd| ?|ff| pour obtenir la " \
-            "liste des ordres disponibles ainsi que leur syntaxe."
+            "composée que de quelques lettres et chiffres."
 
     def interpreter(self, personnage, dic_masques):
         """Interprétation du paramètre"""
         message = supprimer_accents(dic_masques["message"].message)
-        if message == "?":
-            return self.liste_ordres(personnage)
 
         salle = personnage.salle
         if not hasattr(salle, "navire"):


### PR DESCRIPTION
En attendant mieux, cela permettra déjà d'éviter une exception.

Bug 803
